### PR TITLE
Remove devel module dsm from entity form class

### DIFF
--- a/src/Form/PagePropertiesEntityForm.php
+++ b/src/Form/PagePropertiesEntityForm.php
@@ -90,7 +90,6 @@ class PagePropertiesEntityForm extends ContentEntityForm {
       $condition->submitConfigurationForm($form, $condition_values);
       if ($condition instanceof ContextAwarePluginInterface) {
         $context_mapping = isset($values['context_mapping']) ? $values['context_mapping'] : [];
-        dsm($context_mapping);
         $condition->setContextMapping($context_mapping);
       }
       // Update the original form values.


### PR DESCRIPTION
This patch removes a Devel module dsm() call from the PageProperties Entity Form class.

This solved issue https://github.com/zuuperman/wkbe_page_properties/issues/2
